### PR TITLE
fix: fix url in pypi environment

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/wherobots-python-dbapi-driver
+      url: https://pypi.org/p/wherobots-python-dbapi
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
This is not vital to release but nice to clean up the legacy name