### PR TITLE
Migrate GitHub Actions from ubuntu runners to Depot runners

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-small
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   pypi-publish:
     name: Upload release to PyPI
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     environment:
       name: pypi
       url: https://pypi.org/p/wherobots-python-dbapi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']


### PR DESCRIPTION
## Summary
Migrating GitHub Actions workflows to use Depot runners for improved performance and cost efficiency.

## Changes
- `.github/workflows/pre-commit.yaml`: Changed `ubuntu-latest` → `depot-ubuntu-24.04-small` (linting/validation)
- `.github/workflows/pypi-publish.yaml`: Changed `ubuntu-latest` → `depot-ubuntu-24.04` (package building/publishing)
- `.github/workflows/test.yaml`: Changed `ubuntu-latest` → `depot-ubuntu-24.04` (Python matrix testing)

## Runner Selection Rationale
- `depot-ubuntu-24.04-small`: Used for lightweight pre-commit checks
- `depot-ubuntu-24.04`: Used for package building and multi-version Python testing

## Test Plan
- Verify pre-commit hooks run correctly with small runner
- Ensure package builds and publishes successfully
- Confirm tests pass across all Python versions (3.8-3.13)