### PR TITLE
fix use of parameters arg in Cursor.execute

### DIFF
--- a/wherobots/db/cursor.py
+++ b/wherobots/db/cursor.py
@@ -80,9 +80,7 @@ class Cursor:
         self.__rowcount = -1
         self.__description = None
 
-        sql = (
-            operation.replace("{", "{{").replace("}", "}}").format(**(parameters or {}))
-        )
+        sql = operation.format(**(parameters or {}))
         self.__current_execution_id = self.__exec_fn(sql, self.__on_execution_result)
 
     def executemany(


### PR DESCRIPTION
There is still a problem - we don't sanitize these inputs even though users would assume that we do