### PR TITLE
feat: add AWS US East 2 (Ohio) region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ You must also specify in which region your SQL session should execute
 into. Wherobots Cloud supports the following compute regions:
 
 * `aws-us-east-1`: AWS US East 1 (N. Virginia)
+* `aws-us-east-2`: AWS US East 2 (Ohio)
 * `aws-us-west-2`: AWS US West 2 (Oregon)
 * `aws-eu-west-1`: AWS EU West 1 (Ireland)
 * `aws-ap-south-1`: AWS AP South 1 (Mumbai)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wherobots-python-dbapi"
-version = "0.25.4"
+version = "0.26.0"
 description = "Python DB-API driver for Wherobots DB"
 authors = [{ name = "Maxime Petazzoni", email = "max@wherobots.com" }]
 requires-python = ">=3.10, <4"

--- a/wherobots/db/region.py
+++ b/wherobots/db/region.py
@@ -4,6 +4,7 @@ from enum import Enum
 class Region(Enum):
     # Americas
     AWS_US_EAST_1 = "aws-us-east-1"
+    AWS_US_EAST_2 = "aws-us-east-2"
     AWS_US_WEST_2 = "aws-us-west-2"
 
     # EMEA


### PR DESCRIPTION
## Summary

Add `aws-us-east-2` (Ohio) as a supported compute region and bump version to 0.26.0.

## Related Issues

N/A

---

## Requester Checklist

- [x] I have self-reviewed my own code
- [ ] I have added/updated tests that prove my fix/feature works
- [x] I have included visual proof (screenshot, video, or test output) if applicable
- [ ] All CI checks are passing
- [x] PR size is S/M, OR I have justified the size and added a walkthrough
- [x] I have updated documentation if needed

### Visual Proof

Enum-only change — no runtime behavior to screenshot. Region is passed as a query parameter to the API; no client-side routing involved.

---

## Reviewer Checklist

- [ ] Requester checklist above is complete
- [ ] All CI checks are passing
- [ ] Tests adequately cover the changes