### PR TITLE
chore: bump package version to 0.28.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wherobots-python-dbapi"
-version = "0.27.0"
+version = "0.28.0"
 description = "Python DB-API driver for Wherobots DB"
 authors = [{ name = "Maxime Petazzoni", email = "max@wherobots.com" }]
 requires-python = ">=3.10, <4"

--- a/uv.lock
+++ b/uv.lock
@@ -1147,7 +1147,7 @@ wheels = [
 
 [[package]]
 name = "wherobots-python-dbapi"
-version = "0.25.3"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "cbor2" },
@@ -1187,10 +1187,10 @@ requires-dist = [
     { name = "pandas-stubs", specifier = ">=2.0.3.230814" },
     { name = "pyarrow", specifier = ">=14.0.2" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.2" },
-    { name = "requests", specifier = ">=2.32.3" },
+    { name = "requests", specifier = ">=2.31.0" },
     { name = "strenum", specifier = ">=0.4.15,<0.5" },
     { name = "tenacity", specifier = ">=8.2.3" },
-    { name = "types-requests", specifier = ">=2.32.0.20241016" },
+    { name = "types-requests", specifier = ">=2.31.0" },
     { name = "websockets", specifier = ">=13.0" },
 ]
 provides-extras = ["test"]


### PR DESCRIPTION
## Summary
- Bump `wherobots-python-dbapi` to **0.28.0**.
- Release vehicle for #67 (`region`/`runtime` accept `str | enum` and become optional → API applies the organization's configured default).
- v0.27.0 was already published from a previous release, so we move straight to 0.28.0 for the new feature (minor bump under 1.x semver: additive + new optional behavior).
- `uv.lock` refresh also picks up the looser `requests` / `types-requests` specifiers that were relaxed in #60 but never re-locked.

## Test plan
- [x] CI green (lint + tests against Python 3.10–3.14)
- [x] Verified locally against staging: omit region/runtime → API applies org default; raw BYOC string → passthrough; `Region` enum still works