### PR TITLE
fix: stop shipping empty top-level wherobots/__init__.py (0.28.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wherobots-python-dbapi"
-version = "0.28.0"
+version = "0.28.1"
 description = "Python DB-API driver for Wherobots DB"
 authors = [{ name = "Maxime Petazzoni", email = "max@wherobots.com" }]
 requires-python = ">=3.10, <4"

--- a/uv.lock
+++ b/uv.lock
@@ -1147,7 +1147,7 @@ wheels = [
 
 [[package]]
 name = "wherobots-python-dbapi"
-version = "0.28.0"
+version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "cbor2" },


### PR DESCRIPTION
## Summary
- Delete the empty `wherobots/__init__.py` from the dbapi source tree.
- Bump version `0.28.0` → `0.28.1`.

## The bug
Both `wherobots-python-dbapi` 0.28.0 and `wherobots-python-sdk` 0.2.0 claim ownership of `wherobots/__init__.py`:
- dbapi's was a 0-byte file (looks like an old setuptools leftover).
- sdk's is a 1.7 KB file that re-exports the public API (`WherobotsJob`, `WherobotsConfig`, enums, models, …).

When both wheels land in the same environment, whichever installs last wins. The default `pip install wherobots-python-dbapi wherobots-python-sdk` ordering puts dbapi last → its empty `__init__.py` overwrites sdk's → ` from wherobots import WherobotsJob` raises `ImportError`. `from wherobots.db import …` keeps working in either order because submodule imports bypass the parent's `__init__.py`, so dbapi-only consumers (and `airflow-providers-wherobots`, which only uses `wherobots.db.*`) aren't affected.

## The fix
Remove the empty file from dbapi's source. `wherobots/` then becomes a PEP 420 implicit namespace package from dbapi's perspective; the Jobs SDK's `__init__.py` is the canonical one whenever both packages are installed. dbapi's exports live entirely under `wherobots.db.*`, which is unaffected.

## Verified
Built the wheel locally and tested all three install orderings against `wherobots-python-sdk==0.2.0` from PyPI:

| Order | `from wherobots import WherobotsJob` | `from wherobots.db import connect, Region` |
|---|---|---|
| dbapi first, sdk second | ✅ | ✅ |
| sdk first, dbapi second | ✅ | ✅ |
| both in one `pip install` | ✅ | ✅ |

Existing tests: 72/72 unit tests pass.

## Repro of the bug on the current PyPI release (before this PR)
```
uv venv /tmp/v && VIRTUAL_ENV=/tmp/v uv pip install wherobots-python-dbapi==0.28.0 wherobots-python-sdk==0.2.0
cd /tmp && /tmp/v/bin/python -c "from wherobots import WherobotsJob"
# ImportError: cannot import name 'WherobotsJob' from 'wherobots'
```

## Test plan
- [x] CI green (lint + tests across 3.10–3.14)
- [ ] After merge + `v0.28.1` tag, confirm `pip index versions wherobots-python-dbapi` shows `0.28.1` and the wheel contents no longer include `wherobots/__init__.py`
- [ ] Re-run the side-by-side install repro against the published 0.28.1